### PR TITLE
Update PlaidBridgeAPI_Dockerfile

### DIFF
--- a/Dockerfile/PlaidBridgeAPI_Dockerfile
+++ b/Dockerfile/PlaidBridgeAPI_Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir -p /app/logs && mkdir -p /app/statements
 EXPOSE 5000
 
 # Use a non-root user for security
-RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+# RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 USER appuser
 
 # Command to run the Flask app


### PR DESCRIPTION
Consistency: Your local development environment should ideally mirror your deployment environment as closely as possible. If you need this change to build locally, you'll likely need it (or a similar solution) when Azure Container Apps builds your image from the repository.
Collaboration: If you're working with a team, everyone should be using the same version of the Dockerfile.
Future Deployments: Any future builds or deployments from your GitHub repository will use the version of the Dockerfile that's currently in the repo. If you don't update it, you'll likely encounter the same issue in Azure.